### PR TITLE
Add benchmark folder and workflow

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,38 @@
+name: Run benchmarks
+
+on:
+  pull_request:
+    paths:
+      - "src/**"
+      - "benchmark/**"
+      - "Project.toml"
+      - "benchmark/Project.toml"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  # Skip intermediate builds: always.
+  # Cancel intermediate builds: only if it is a pull request build.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  benchmark:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: 1
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Install dependencies
+        run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
+      - name: Run benchmarks
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(baseline="origin/main")'
+      - name: Post results
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.postjudge()'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/benchmark/Project.toml
+++ b/benchmark/Project.toml
@@ -1,0 +1,4 @@
+[deps]
+ADNLPModels = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+JSOSuite = "ed6ae0be-a024-11e9-2788-05dbf8cd15d9"

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -1,0 +1,14 @@
+using BenchmarkTools, ADNLPModels
+using JSOSuite
+
+# Run locally with `tune!(SUITE)` and then `run(SUITE)`
+const SUITE = BenchmarkGroup()
+
+SUITE["solvers"] = BenchmarkGroup(["solver"])
+
+nlp = ADNLPModel(x -> (x[1] - 1)^2 + 4 * (x[2] - x[1]^2)^2, [-1.2; 1.0])
+for solver in eachrow(JSOSuite.select_optimizers(nlp))
+  SUITE["solvers"][solver.name] = @benchmarkable begin
+    minimize($(solver.name), $nlp)
+  end
+end


### PR DESCRIPTION
This adds a simple benchmark script. It should help track improvements and regressions.
After it is merged, it will run the benchmark whenever there are any modifications to the `src` folder and post the results here.
It only works for branches from inside the repo, so no forks.