### PR TITLE
Add `ExpressionTreeForge.extract_element_functions` in parse-function.jl

### DIFF
--- a/src/parse-functions.jl
+++ b/src/parse-functions.jl
@@ -14,7 +14,7 @@ then try to detect the least squares pattern. There is no guarantee that this fu
 """
 function isnls(nlp)
   expr_tree = ExpressionTreeForge.get_expression_tree(nlp)
-  F_expr = extract_element_functions(expr_tree)
+  F_expr = ExpressionTreeForge.extract_element_functions(expr_tree)
   test_square(expr) = expr.field == ExpressionTreeForge.M_power_operator.Power_operator{Int}(2)
   is_nls = mapreduce(test_square, &, F_expr) :: Bool
   return is_nls 

--- a/test/parse-function-test.jl
+++ b/test/parse-function-test.jl
@@ -1,18 +1,22 @@
 problems_names = meta[!,:name][1:50] # we test only the 50 first problems
 problems_symbols = map(name -> OptimizationProblems.ADNLPProblems.eval(Meta.parse(name)), problems_names)
 
-result_list_isnls = Bool[]
-@testset "Test NLS parser" for (index, problem) in enumerate(problems_symbols)
-  @debug "$index : $problem"
-  try
-    detect_nls = JSOSuite.isnls(problem())
-    is_nls = meta[meta.name .== problems_names[index], :objtype][1] == :least_squares
-    push!(result_list_isnls, detect_nls)
-    if detect_nls
-      @test detect_nls == is_nls
-      @debug "Least squares objective"
-    end
-  catch 
-    @debug "the $index-th $(problems_names[index]) problem is unsupported."
-  end 
+@testset "NLS from NLP" begin
+  result_list_isnls = Bool[]
+  for (index, problem) in enumerate(problems_symbols)
+    try
+      detect_nls = JSOSuite.isnls(problem())
+      is_nls = meta[meta.name .== problems_names[index], :objtype][1] == :least_squares
+      push!(result_list_isnls, detect_nls)
+      if detect_nls
+        @test detect_nls == is_nls
+        @debug "Least squares objective, $index : $problem"
+        # detect_nls != is_nls && (@debug "$index : $problem")
+      else 
+        @debug "Not least squares objective, $index : $problem"
+      end
+    catch 
+      @debug "the $index-th $(problems_names[index]) problem is unsupported."
+    end 
+  end
 end


### PR DESCRIPTION
By adding `ExpressionTreeForge.` to `extract_element_functions` I got the tests running locally.

However, I am not sure about the purpose of the current tests.
If I understand correctly, each test using `isnls` checks if the result `detect_nls` is equal to what is informed by `is_nls`
```julia
is_nls = meta[meta.name .== problems_names[index], :objtype][1] == :least_squares
```
I took a look at the results, here is a summary:
- problem 25 ([NZF1](https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/blob/main/src/ADNLPProblems/NZF1.jl)) is recognized as a least square problem by `detect_nls`.
The ADNLPModel is a sum of squared terms.
Nonetheless, the test fails for this one since `is_nls` returns `false`;
- the same case happens for the problem 43 [avions2](https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/blob/main/src/ADNLPProblems/avion2.jl);
- however, the 48-th problem bennett5 is unsupported for now.
An Error is generated from `get_expression_tree()`.
The `try ... catch` part of the test loop handles it well (by preventing the test `is_nls == detect_nls` to happen).

Out of 50 problems, 49 are supported, and two of them are least squares problems (producing errors in tests).


## Checklist

<!-- mark true if NA -->
<!-- leave PR as draft until all is checked -->
- [X] I am following the [contributing guidelines](https://github.com/JuliaSmoothOptimizers/JSOSuite.jl/blob/main/docs/src/90-contributing.md)
- [ ] Tests are passing
